### PR TITLE
Fix if /var/mail directory exists

### DIFF
--- a/docker/wp-cli/Dockerfile
+++ b/docker/wp-cli/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache zip shadow
 
 COPY php.conf.ini /usr/local/etc/php/conf.d/conf.ini
 
-RUN mkdir /var/mail 
+RUN mkdir -p /var/mail 
 RUN userdel -f www-data &&\
     useradd -l -u ${USER_ID} www-data
 


### PR DESCRIPTION
Currently, the script is failing with `mkdir: can't create directory '/var/mail': File exists`. This is a silent fix.